### PR TITLE
Added links to generated RSS feed for discovery

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,7 @@
     <link href="{{site.url}}{{site.baseurl}}/assets/css/style.css" type="text/css" rel="stylesheet"></link>
     <link href="https://fonts.googleapis.com/css?family=Cutive+Mono" rel="stylesheet">
     <link rel="icon" type="image/x-icon" href="{{site.url}}{{site.baseurl}}/assets/images/favicon-light.ico">
+    <link rel="alternate" type="application/rss+xml" title="RSS Feed for {{site.title}}" href="{{site.url}}{{site.baseurl}}/feed.xml" />
     <meta content="{{site.description}}" name="description"></meta>
     <meta content="{{site.owner}}" name="author"></meta>
     <meta content="Copyright 2019 {{site.owner}}. All rights reserved." name="copyright"></meta>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,5 +1,6 @@
 <div id="nav">
   <a href="{{site.url}}{{site.baseurl}}/">Blog</a> ·
   <a href="{{site.url}}{{site.baseurl}}/about/">About</a> ·
+  <a href="{{site.url}}{{site.baseurl}}/feed.xml">Feed</a> ·
   <a href="{{site.url}}{{site.baseurl}}/projects/">Projects</a>
 </div>


### PR DESCRIPTION
Today, the jekyll feed plugin generates but it is not visible/discoverable to reader.

This change exposes the feed at two places.

- In the html using the `link` tag for browsers to be able to auto discover the feed. ([reference](https://stackoverflow.com/a/11412854))
- In the nav for users who want to consume the feed through other readers.

---

This is how the nav looks after the change.
![Nav bar screen shot](https://user-images.githubusercontent.com/2378083/69014081-75a9bc80-093b-11ea-8231-a6142faaa98e.png)

I added the feed link in the middle as opposed to the end because ends are (arguably) the most important real estate for the reader.

But i can change the ordering if request.

---
Thanks for the awesome blog and projects!
